### PR TITLE
Fix for no initial group name.

### DIFF
--- a/usr/share/openmediavault/engined/rpc/vdr.inc
+++ b/usr/share/openmediavault/engined/rpc/vdr.inc
@@ -202,7 +202,7 @@ class OMVRpcServiceVdr extends OMVRpcServiceAbstract
         $groupStack = new SplStack();
         $file = new SplFileInfo($this->channelsFileLocation);
         $targetFile = new SplFileInfo($file->getLinkTarget());
-
+        
         // The target file doesn't exist yet so no channels can be loaded.
         // Exit early.
         if (!$targetFile->isFile()) {
@@ -222,8 +222,10 @@ class OMVRpcServiceVdr extends OMVRpcServiceAbstract
                     continue;
                 }
 
-                // Pop from stack (emulated stack behaviour)
-                $channelGroup = $groupStack->pop();
+                // Set a generic group, then pop from stack is value exists (emulated stack behaviour)
+                $channelGroup = ":UnGrouped";
+                if (!$groupStack->isEmpty())
+					$channelGroup = $groupStack->pop();
 
                 $channelPortions = explode(":", $channelString);
                 $channelNameCompany = explode(";", $channelPortions[0]);


### PR DESCRIPTION
Some w_scan scans do not begin with group names. This would cause a 'Can't pop from an empty datastructure' exception.

Instead, $channelGroup should be defined then replaced if a suitable value exists.